### PR TITLE
Fix decoding unpacked repeated fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: elm
 
+node_js: '11' # as the LTS suffers from https://github.com/elm/core/issues/958
+
 elm:
   - "0.19.0"

--- a/src/Protobuf/Decode.elm
+++ b/src/Protobuf/Decode.elm
@@ -360,7 +360,7 @@ repeated fieldNumber (Decoder decoder) get set =
                             Decode.loop ( width, [] ) (stepPackedField width (decoder wireType))
 
                         _ ->
-                            Decode.fail
+                            Decode.map (Tuple.mapSecond List.singleton) (decoder wireType)
                 )
 
         update value model =


### PR DESCRIPTION
As reported here: https://github.com/eriktim/protoc-gen-elm/issues/6.

The decoder fails when decoding repeated fields that where not packed.