### PR TITLE
Fix performance issue

### DIFF
--- a/src/Protobuf/Decode.elm
+++ b/src/Protobuf/Decode.elm
@@ -778,10 +778,10 @@ stepPackedField fullWidth decoder ( width, values ) =
                     width - w
 
                 values_ =
-                    values ++ [ value ]
+                    value :: values
             in
             if bytesRemaining <= 0 then
-                Decode.Done ( fullWidth, values_ )
+                Decode.Done ( fullWidth, List.reverse values_ )
 
             else
                 Decode.Loop ( bytesRemaining, values_ )


### PR DESCRIPTION
Decoding large packed lists of values is very slow due to each item being placed on the end of the list instead of at the beginning (in my use case, this issue made decoding take 15 seconds instead of 100ms). This PR fixes that issue.