### PR TITLE
Add `protobuf` to description

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 16.x
 
       - name: install elm
-        run: npm install elm elm-test elm-format
+        run: npm install elm@0.19.1-5 elm-test@0.19.1-revision9 elm-format@0.8.5
 
       - name: elm-format
         run: npx elm-format --validate src/ tests/

--- a/elm.json
+++ b/elm.json
@@ -1,7 +1,7 @@
 {
     "type": "package",
     "name": "eriktim/elm-protocol-buffers",
-    "summary": "An Elm implementation of the Protocol Buffers specification",
+    "summary": "An Elm implementation of the Protocol Buffers (protobuf) specification",
     "license": "BSD-3-Clause",
     "version": "1.1.1",
     "exposed-modules": [


### PR DESCRIPTION
So the package can be found by searching for `protobuf`.

See also https://github.com/rtfeldman/node-test-runner#versions regarding the version locking.